### PR TITLE
workflows: ensure that `grist-ee` is also getting tagged

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,19 +41,39 @@ jobs:
         if: matrix.image.name != 'grist-oss'
         run: buildtools/checkout-ext-directory.sh ${{ matrix.image.repo }}
 
+      - name: Generate metadata tag input
+        id: meta_input
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "type=ref,event=branch"
+            echo "type=ref,event=pr"
+            echo "type=semver,pattern={{version}}"
+            echo "type=semver,pattern={{major}}.{{minor}}"
+            echo "type=semver,pattern={{major}}"
+            echo "${{ env.TAG }}"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ github.repository_owner }}/${{ matrix.image.name }}
+            ${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            ${{ env.TAG }}
+            ${{ steps.meta_input.outputs.tags }}
+
+      - name: Docker meta (EE)
+        if: ${{ matrix.image.name == 'grist' }}
+        id: meta_ee
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.DOCKER_HUB_OWNER }}/grist-ee
+          tags: |
+            ${{ steps.meta_input.outputs.tags }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -90,6 +110,6 @@ jobs:
           file: ext/Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true
-          tags: ${{ env.DOCKER_HUB_OWNER }}/grist-ee:${{ env.TAG }}
+          tags: ${{ steps.meta_ee.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/app/common/LoginSessionAPI.ts
+++ b/app/common/LoginSessionAPI.ts
@@ -5,7 +5,7 @@ import {UserPrefs} from 'app/common/Prefs';
 export interface UserProfile {
   email: string;          // TODO: Used inconsistently: as lowercase login email or display email.
   name: string;
-  loginEmail?: string;    // When set, this is consistently normalized (lowercase) login email.
+  loginEmail?: string;   // When set, this is consistently normalized (lowercase) login email.
   picture?: string|null; // when present, a url to a public image of unspecified dimensions.
   anonymous?: boolean;   // when present, asserts whether user is anonymous (not authorized).
   connectId?: string|null, // used by GristConnect to identify user in external provider.


### PR DESCRIPTION
## Context

We noticed that `grist-ee` wasn't getting individual version tags on Docker Hub. So we need to add those tags.

## Proposed solution

This is done in three steps:

1) Save the inputs of the "Docker meta" action to a separate build step.
2) Create a new "Docker meta (EE)" step that is the same, but using the `grist-ee` image
3) Use the output of this new build step to push `grist-ee` to Docker Hub.

## Has this been tested?

Manual testing because I don't think there's any other way to test Github Actions.